### PR TITLE
Add error log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- An Error Log, showing the last 100 errors from `XMLHttpRequest`s. Available from the
+  extension settings page.
+
 - An options page to specify the server to target for recording, as well the
   AppLand server for uploading.
   

--- a/errors/errors.css
+++ b/errors/errors.css
@@ -1,0 +1,146 @@
+@font-face {
+  font-family: 'Nunito Sans';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local('Nunito Sans Regular'), local('NunitoSans-Regular'), url(/fonts/NunitoSans-Regular.ttf) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+p > label {
+  display: block;
+}
+
+body {
+  background-color: #171e2f;
+  font-family: 'Nunito Sans';
+  padding: 3rem;
+  color: #EAEAEA;
+  font-size: 16px;
+  line-height: 1.8rem;
+}
+
+header {
+  margin-bottom: 2rem; 
+}
+
+header img {
+  width: 300px;
+}
+
+.container {
+  max-width: 1440px;
+  margin: 0 auto;
+}
+
+.card {
+  border-radius: 4px;
+  background-color: #010306;
+  padding: 1.25rem;
+}
+
+.radio {
+  display: flex;
+  flex-direction: row;
+}
+
+.radio .form {
+  margin-right: 2rem;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.controls-wrap {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 2rem;
+}
+
+.error-label {
+  color: #4362b1;
+  font-weight: 800;
+}
+
+.form label {
+  width: 100%;
+  display: block;
+}
+
+.form input {
+  flex: 1;
+  padding-right: .5rem; 
+  color: #EAEAEA;
+  border-radius: 4px;
+  border: 1px solid #343742;
+  margin: 0 .25rem 0 0;
+  background-color: transparent;
+  font-size: 1rem;
+}
+
+h1 {
+  margin: .25rem 0 .5rem 0;
+  font-weight: 500;
+  color: #808b98;
+}
+.option {
+  padding: .5rem 0;
+  display: flex;
+  align-items: center;
+}
+
+.option label, .option input {
+  margin-left: .25rem;
+}
+
+.option input{
+  color: #EAEAEA;
+  font-size: 1rem;
+}
+
+button {
+  margin-right: 1rem;
+}
+
+.btn {
+  border-radius: 4px;
+  border: 0;
+  box-shadow: none;
+  color: #EAEAEA;
+  padding: .5rem .8rem;
+  font-size: 1rem;
+}
+
+.btn-primary {
+  background-color: #FF07AA;
+}
+
+.btn-primary:hover {
+  background-color: #9a0e6a;
+}
+
+details {
+  padding: 0;
+  border-radius: 4px;
+  background-color: #010306;
+  margin-bottom: 1rem;
+}
+
+details ul {
+  list-style-type: none;
+  padding: 0;
+}
+
+details ul li {
+  padding: .5rem 1.25rem;
+  border-bottom: 1px solid #343742;
+  color: #808b98;
+}
+
+details ul li:last-of-type {
+  border: 0;
+}
+
+summary {
+  padding: 1rem 1.25rem;
+}

--- a/errors/errors.html
+++ b/errors/errors.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <meta charset="utf-8">
+  </head>
+
+  <body>
+    <h3>Error Log</h3>
+    <input type="radio" name="order" id="newest_first" value="newest_first" checked><label for="newest_first">Newest First</label>
+    <input type="radio" name="order" id="oldest_first" value="oldest_first"><label for="oldest_first">Oldest First</label>
+    <input type="checkbox" id="show_all"><label for="show_all">Show All</label>
+    <button id="reload">Reload</button>
+    <button id="delete_all">Delete All...</button>
+    <div id="errors"></div>
+  </body>
+
+  <script src="errors.js" type="module"></script>
+</html>

--- a/errors/errors.html
+++ b/errors/errors.html
@@ -3,16 +3,40 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <link href="errors.css" rel="stylesheet" type="text/css">
   </head>
 
   <body>
-    <h3>Error Log</h3>
-    <input type="radio" name="order" id="newest_first" value="newest_first" checked><label for="newest_first">Newest First</label>
-    <input type="radio" name="order" id="oldest_first" value="oldest_first"><label for="oldest_first">Oldest First</label>
-    <input type="checkbox" id="show_all"><label for="show_all">Show All</label>
-    <button id="reload">Reload</button>
-    <button id="delete_all">Delete All...</button>
-    <div id="errors"></div>
+
+    <div class="container">
+
+      <header>
+        <img src="/images/appland-logo-sharp.svg"/>
+        <h1>Error log</h1>
+      </header>
+      
+      <div class="card controls-wrap">
+        <div class="radio">
+          <div class="form">
+            <input type="radio" name="order" id="newest_first" value="newest_first" checked><label for="newest_first">Newest First</label>
+          </div>
+          <div class="form">
+            <input type="radio" name="order" id="oldest_first" value="oldest_first"><label for="oldest_first">Oldest First</label>
+          </div>
+          <div class="form">
+            <input type="checkbox" id="show_all"><label for="show_all">Show All</label>
+          </div>
+        </div>
+        
+        <div class="controls">
+          <button id="reload" class="btn btn-primary">Reload</button>
+          <button id="delete_all" class="btn btn-primary">Delete All...</button>
+        </div>
+      </div>
+     
+    </div>
+    
+    <div id="errors" class="container"></div>
   </body>
 
   <script src="errors.js" type="module"></script>

--- a/errors/errors.js
+++ b/errors/errors.js
@@ -57,12 +57,12 @@ async function showErrors() {
     ${entry.ts} ${entry.status} ${entry.msg}
   </summary>    
     <ul>
-      <li>${entry.ts}</li>
-      <li>${entry.status}</li>
-      <li>${entry.msg}</li>
+      <li><span class="error-label">ts:</span> ${entry.ts}</li>
+      <li><span class="error-label">status:</span> ${entry.status}</li>
+      <li><span class="error-label">msg:</span> ${entry.msg}</li>
 `;
       if (entry.resp) {
-        error += `<li>${entry.resp}</li>\n`;
+        error += `<li><span class="error-label">resp:</span> ${entry.resp}</li>\n`;
       }
       error += `
     </ul>

--- a/errors/errors.js
+++ b/errors/errors.js
@@ -54,10 +54,11 @@ async function showErrors() {
       let error = `
 <details ${showAllCb.checked? "open" : ""}>
   <summary>
-    ${entry.ts} ${entry.status} ${entry.msg}
+    ${entry.ts} ${entry.msg}
   </summary>    
     <ul>
       <li><span class="error-label">ts:</span> ${entry.ts}</li>
+      <li><span class="error-label">url:</span> ${entry.url}</li>
       <li><span class="error-label">status:</span> ${entry.status}</li>
       <li><span class="error-label">msg:</span> ${entry.msg}</li>
 `;

--- a/errors/errors.js
+++ b/errors/errors.js
@@ -1,0 +1,82 @@
+import * as utils from '/utils.js';
+const errorsDiv = document.querySelector('#errors');
+const newestFirstBtn = document.querySelector('#newest_first');
+const oldestFirstBtn = document.querySelector('#oldest_first');
+const showAllCb = document.querySelector('#show_all');
+const reloadBtn = document.querySelector('#reload');
+const deleteAllBtn = document.querySelector('#delete_all');
+
+document.addEventListener('DOMContentLoaded', onLoad);
+newestFirstBtn.addEventListener('change', reload);
+oldestFirstBtn.addEventListener('change', reload);
+
+showAllCb.addEventListener('click', (e) => {
+  document.querySelectorAll('details').forEach((e) => {
+    e.open = showAllCb.checked;
+  });
+});
+reloadBtn.addEventListener('click', reload);
+
+deleteAllBtn.addEventListener('click', (e) => {
+  if (confirm('Delete all log entries?')) {
+    utils.deleteErrors().then(reload);
+  }
+});
+
+async function reload() {
+  document.location.reload();
+}
+
+async function onLoad(e) {
+  showErrors();
+}
+
+async function showErrors() {
+  const compare = (e1, e2) => {
+    if (e1.ts < e2.ts) {
+      return -1;
+    }
+    if (e1.ts > e2.ts) {
+      return 1;
+    }
+    return 0;
+  };
+  const newestFirst = newestFirstBtn.checked;
+  
+  utils.getErrors().then((entries) => {
+    const sorted = entries.sort((e1,e2) => 
+      newestFirst? compare(e1,e2) : compare(e2,e1)
+    );
+
+    const allErrorsDiv = document.createElement('div');
+    allErrorsDiv.id = 'all_errors';
+    entries.forEach((entry) => {
+      let error = `
+<details ${showAllCb.checked? "open" : ""}>
+  <summary>
+    ${entry.ts} ${entry.status} ${entry.msg}
+  </summary>    
+    <ul>
+      <li>${entry.ts}</li>
+      <li>${entry.status}</li>
+      <li>${entry.msg}</li>
+`;
+      if (entry.resp) {
+        error += `<li>${entry.resp}</li>\n`;
+      }
+      error += `
+    </ul>
+</details>
+`;
+      
+      allErrorsDiv.insertAdjacentHTML('afterbegin', error);
+    });
+    if (allErrorsDiv.childElementCount === 0) {
+      const noErrorsText = document.createTextNode('No errors');
+      allErrorsDiv.appendChild(noErrorsText);
+    }
+    errorsDiv.appendChild(allErrorsDiv);
+      
+  });
+}
+

--- a/options.js
+++ b/options.js
@@ -1,35 +1,11 @@
-export default function Options() {
-  function readFromStorage(key) {
-    return new Promise((resolve, reject) => {
-      chrome.storage.local.get(key, (result) => {
-        if (!chrome.runtime.lastError) {
-          resolve(result[key]);
-        }
-        else {
-          reject(Error(chrome.runtime.lastError.message));
-        }
-      });
-    });
-  };
+import * as utils from '/utils.js';
 
-  function writeToStorage(key, value) {
-    let entry = {[key.toString()]: value};
-    return new Promise((resolve, reject) => {
-      chrome.storage.local.set(entry, () => {
-        if (!chrome.runtime.lastError) {
-          resolve(value);
-        }
-        else {
-          reject(Error(chrome.runtime.lastError.message));
-        }
-      });
-    })
-  };
+export default function Options() {
 
   this.defaultAppLandUrl = () => chrome.runtime.getManifest().homepage_url;
   const applandUrlKey = 'applandUrl';
   this.getAppLandUrl = async function() {
-    return readFromStorage(applandUrlKey).then((value) => {
+    return utils.readFromStorage(applandUrlKey).then((value) => {
       if (value) {
         return value;
       }
@@ -39,13 +15,13 @@ export default function Options() {
     });
   };
   this.setAppLandUrl = async function(url) {
-    return writeToStorage(applandUrlKey, url);
+    return utils.writeToStorage(applandUrlKey, url);
   };
   
 
   const useCurrentKey = 'useCurrent';
   this.getUseCurrent = async function() {
-    return readFromStorage(useCurrentKey).then((value) => {
+    return utils.readFromStorage(useCurrentKey).then((value) => {
       if (typeof value !== 'undefined') {
         return value;
       }
@@ -54,12 +30,12 @@ export default function Options() {
     });
   };
   this.setUseCurrent = async function(useCurrent) {
-    return writeToStorage(useCurrentKey, useCurrent);
-  }
+    return utils.writeToStorage(useCurrentKey, useCurrent);
+  };
   
   const alternateUrlKey = 'alternateUrl';
   this.getAlternateUrl = async function() {
-    return readFromStorage(alternateUrlKey).then((url) => {
+    return utils.readFromStorage(alternateUrlKey).then((url) => {
       if (typeof url !== 'undefined') {
         return url;
       }
@@ -68,6 +44,10 @@ export default function Options() {
     });
   };
   this.setAlternateUrl = async function(url) {
-    return writeToStorage(alternateUrlKey, url);
+    return utils.writeToStorage(alternateUrlKey, url);
+  };
+
+  this.getSaveErrors = async function() {
+    return Promise.resolve(true);
   };
 };

--- a/popup/record.html
+++ b/popup/record.html
@@ -19,8 +19,7 @@
 
     </div>
 
-    <script src="/utils.js"></script>
-    <script type="module" src="record.js"></script>
+    <script src="record.js" type="module"></script>
   </body>
 
 </html>

--- a/popup/record.js
+++ b/popup/record.js
@@ -1,3 +1,4 @@
+import * as utils from '/utils.js';
 import Options from "/options.js";
 
 const statusElement = document.querySelector('.status');
@@ -32,7 +33,7 @@ async function onHeaderClick() {
 async function getTarget() {
   return options.getUseCurrent().then((useCurrent) => {
     if (useCurrent) {
-      return getTabUrl();
+      return utils.getTabUrl();
     }
 
     return options.getAlternateUrl().then((url) => {
@@ -50,7 +51,7 @@ function startRecording() {
         displayRecording(true);
       }
       else {
-        showXHRError(req, 'Failed to start recording');
+        utils.showXHRError(req, 'Failed to start recording');
       }
     };
     req.send();
@@ -124,9 +125,12 @@ async function onLoad() {
         displayRecording(recordingState.enabled);
         setEnabled(true);
       } else {
-        showXHRError(req, 'Failed checking recording status');
+        utils.showXHRError(req, 'Failed checking recording status');
         setStatus('Not available for this domain');
       }
+    };
+    req.onerror = () => {
+      utils.showXHRError(req, 'Network error checking recording status');
     };
     req.send();
   });

--- a/popup/save.html
+++ b/popup/save.html
@@ -9,7 +9,7 @@
       <input name="data" type="hidden">
     </form>
     
-    <script src="/utils.js"></script>
-    <script type="module" src="save.js"></script>
+    <script src="/utils.js" type="module"></script>
+    <script src="save.js" type="module"></script>
   </body>
 </html>

--- a/settings/settings.css
+++ b/settings/settings.css
@@ -1,0 +1,143 @@
+@font-face {
+  font-family: 'Nunito Sans';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local('Nunito Sans Regular'), local('NunitoSans-Regular'), url(/fonts/NunitoSans-Regular.ttf) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+p > label {
+  display: block;
+}
+
+body {
+  background-color: #171e2f;
+  padding: 3rem;
+  color: #EAEAEA;
+  font-size: 16px;
+  line-height: 1.8rem;
+  font-family: 'Nunito Sans';
+}
+
+a {
+  color: #4362b1;
+}
+
+.container {
+  max-width: 1440px;
+  margin: 0 auto;
+}
+
+#errors_link {
+  margin-left: .5rem;
+}
+
+header {
+  margin-bottom: 2rem;
+}
+
+header img {
+  width: 300px;
+}
+header h2 {
+  font-weight: 500;
+}
+
+.form {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.form label {
+  width: 100%;
+  display: block;
+}
+
+.form input {
+  flex: 1;
+  padding: .5rem; 
+  color: #EAEAEA;
+  border-radius: 4px;
+  border: 1px solid #343742;
+  margin-top: .5rem;
+  background-color: transparent;
+  font-size: 1rem;
+}
+
+.form label {
+  font-size: 1.5rem;
+  font-weight: 500;
+  color: #808b98;
+}
+
+.card {
+  background-color: #010306;
+  border-radius: 4px;
+}
+
+fieldset {
+  margin: 0;
+  border: 0;
+  padding: 0;
+}
+
+h2 {
+  margin: 0 0 .5rem 0;
+  font-weight: 500;
+  color: #808b98;
+}
+.option {
+  padding: .5rem 0;
+  display: flex;
+  align-items: center;
+}
+
+.option label, .option input {
+  margin-left: .25rem;
+}
+
+label span {
+  font-size: 1rem;
+}
+
+.option input{
+  color: #EAEAEA;
+  font-size: 1rem;
+}
+
+.btn {
+  border-radius: 4px;
+  border: 0;
+  box-shadow: none;
+  color: #EAEAEA;
+  padding: .5rem .8rem;
+  font-size: 1rem;
+}
+
+.btn-primary {
+  background-color: #FF07AA;
+}
+
+.btn-primary:hover {
+  background-color: #9a0e6a;
+}
+
+#alternate_url {
+  padding: .5rem;
+  background: transparent;
+  border: 1px solid #343742;
+  border-radius: 4px;
+  width: 50%;
+  flex: 1;
+}
+
+#alternate_url:focus, #appland_url:focus {
+  outline: none;
+}
+
+section {
+  padding: 2rem;
+  margin-bottom: 2rem;
+}

--- a/settings/settings.css
+++ b/settings/settings.css
@@ -1,3 +1,0 @@
-p > label {
-  display: block;
-}

--- a/settings/settings.html
+++ b/settings/settings.html
@@ -7,27 +7,45 @@
   </head>
 
   <body>
-    <form name="settings_form" id="settings">
-      <p>
-        <label for="appland_url">AppLand Server URL (required)</label>
-        <input type="url" id="appland_url" required >
-      </p>
+    <div class="container">
+      <header>
+        <img src="/images/appland-logo-sharp.svg"/>
+        <h2>Browser extension settings</h2>
+      </header>
 
-      <p>
-        <fieldset>
-          <legend>Target Server</legend>
-          <input required type="radio" name="alternate_radio" id="use_current" value="current"><label for="use_current">Use current tab</label>
-          <input required type="radio" name="alternate_radio" id="use_alternate" value="alternate"><label for="use_alternate">Alternate URL</label>
-          <input type="url" id="alternate_url">
-        </fieldset>
-      </p>
+      <form name="settings_form" id="settings">
+        <section class="card">
+          <div class="form">
+            <label for="appland_url">AppLand Server URL <span>(required)</span></label>
+            <input type="url" id="appland_url" required >
+          </div>
+        </section>
+        
+        <section class="card">
+          <h2>Target server</h2>
+          <fieldset>
+            <div class="option">
+              <input required type="radio" name="alternate_radio" id="use_current" value="current"><label for="use_current">Use current tab</label>
+            </div>
+            <div class="option">  
+              <input required type="radio" name="alternate_radio" id="use_alternate" value="alternate"><label for="use_alternate">Alternate URL:</label>
+              <input type="url" id="alternate_url">
+            </div>
+          </fieldset>
+        </section>
 
-      <p>
-        <input type="checkbox" id="save_errors"><label for="save_errors">Save Errors</label>
-        <a id="errors_link">Error Log</a>
-      </p>
-      <button id="save" disabled>Save</button>
-    </form>
+        <section class="card">
+          <h2>Errors</h2>
+          <div class="option">
+          <input type="checkbox" id="save_errors"><label for="save_errors">Save Errors</label>
+          <a id="errors_link">Error Log</a>
+        </div>
+        </section>
+      
+        <button class="btn btn-primary controls" id="save" disabled>Save</button>
+
+      </form>
+    </div>
     
     <script src="settings.js" type="module"></script>
   </body>

--- a/settings/settings.html
+++ b/settings/settings.html
@@ -21,11 +21,14 @@
           <input type="url" id="alternate_url">
         </fieldset>
       </p>
-      
+
+      <p>
+        <input type="checkbox" id="save_errors"><label for="save_errors">Save Errors</label>
+        <a id="errors_link">Error Log</a>
+      </p>
       <button id="save" disabled>Save</button>
     </form>
     
-    <script src="/utils.js"></script>
-    <script type="module" src="settings.js"></script>
+    <script src="settings.js" type="module"></script>
   </body>
 </html>

--- a/settings/settings.js
+++ b/settings/settings.js
@@ -3,9 +3,11 @@ import Options from "/options.js";
 const settingsForm = document.querySelector('#settings');
 const applandUrlInput = document.querySelector('#appland_url');
 const useCurrentButton = document.querySelector('#use_current');
-const useAlternateButton = document.querySelector('#use_alternate')
+const useAlternateButton = document.querySelector('#use_alternate');
 const alternateUrlInput = document.querySelector('#alternate_url');
 const saveButton = document.querySelector('#save');
+const saveErrorsInput = document.querySelector('#save_errors');
+const errorsLink = document.querySelector('#errors_link');
 
 const options = new Options();
 
@@ -53,7 +55,7 @@ async function onSubmit(e) {
 }
 
 async function onLoad(e) {
-  const useCurrent = await options.getUseCurrent()
+  const useCurrent = options.getUseCurrent();
   setAlternateRadio(useCurrent? 'current' : 'alternate');
   
   applandUrlInput.value = await options.getAppLandUrl();
@@ -61,4 +63,10 @@ async function onLoad(e) {
   
   const alternateUrl = await options.getAlternateUrl();
   alternateUrlInput.value = await options.getAlternateUrl();
+
+  const saveErrors = await options.getSaveErrors();
+  saveErrorsInput.checked = saveErrors;
+  if (saveErrors) {
+    errorsLink.href = "/errors/errors.html";
+  }
 }

--- a/utils.js
+++ b/utils.js
@@ -1,12 +1,53 @@
-function showXHRError(req, msg) {
-  console.log(msg);
-  console.log(`status: ${req.status}`);
-  console.log(req.response);
-  alert(msg);
+import Options from "/options.js";
+
+export async function showXHRError(req, msg) {
+  return new Options().getSaveErrors()
+    .then((saveErrors) => {
+      const emptyLog = {idx: 0, entries: []};
+      if (!saveErrors) {
+        return Promise.resolve(emptyLog);
+      }
+      
+      return readFromStorage('log').then((log) => {
+        if (typeof log === 'undefined') {
+          log = emptyLog;
+        }
+        let entry = {
+          ts: new Date().toISOString(),
+          msg: msg,
+          status: req.status
+        };
+
+        // Only record the response for a server error. Other errors
+        // (e.g. 404) won't have interesting content and just take up
+        // space.
+        if (req.status >= 500) {
+          entry.resp =  req.responseText;
+        }
+          
+        log.entries[log.idx++ % 100] = entry ;
+        return writeToStorage('log', log);
+      });
+    })
+    .finally(() => alert(msg));
+}
+
+export async function getErrors() {
+  return readFromStorage('log').then((log) => {
+    if (typeof log === 'undefined') {
+      return [];
+    }
+
+    return log.entries;
+  });
+}
+
+export async function deleteErrors() {
+  return deleteFromStorage('log');
 }
 
 // Get the URL show in the active tab of the current window.
-async function getTabUrl() {
+export async function getTabUrl() {
   return new Promise((resolve, reject) => {
     chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
       const url = new URL(tabs[0].url);
@@ -16,3 +57,43 @@ async function getTabUrl() {
   });
 }
                      
+
+export async function readFromStorage(key) {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.get(key, (result) => {
+      if (!chrome.runtime.lastError) {
+        resolve(result[key]);
+      }
+      else {
+        reject(Error(chrome.runtime.lastError.message));
+      }
+    });
+  });
+};
+
+export async function writeToStorage(key, value) {
+  let entry = {[key.toString()]: value};
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.set(entry, () => {
+      if (!chrome.runtime.lastError) {
+        resolve(value);
+      }
+      else {
+        reject(Error(chrome.runtime.lastError.message));
+      }
+    });
+  });
+};
+
+export async function deleteFromStorage(key) {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.remove(key, () => {
+      if (!chrome.runtime.lastError) {
+        resolve();
+      }
+      else {
+        reject(Error(chrome.runtime.lastError.message));
+      }
+    });
+  });
+}

--- a/utils.js
+++ b/utils.js
@@ -14,6 +14,7 @@ export async function showXHRError(req, msg) {
         }
         let entry = {
           ts: new Date().toISOString(),
+          url: req.responseURL,
           msg: msg,
           status: req.status
         };


### PR DESCRIPTION
### Overview
The last 100 errors generated from `XMLHttpRequest` are now written to local storage. Network errors and responses with status < 500 are recorded without the response body (for the sake of brevity). The body for responses with status >= 500 are saved, as they may indicate a problem with the way the server is configure for recording.

In addition to any suggestions you may have about code or styling, I'm interested to know if:
* there is other information you think would aid in debugging
* you think 100 errors is too few or too many
* you think the different rendering of responses with status < 500 and >= 500 is useful. I did this because extensions are limited to 5MB of local storage, and the body of other responses didn't seem likely to contain interesting information.

### Walkthrough  
The error log can be retrieved by visiting the `Error Log` link from the settings page:
![Screen Shot 2020-06-08 at 6 08 52 PM](https://user-images.githubusercontent.com/123787/84085288-3ca66780-a9b3-11ea-9241-becb6392e174.png)

Errors will have summaries that look like this:
<img width="1234" alt="ty-errors jpg" src="https://user-images.githubusercontent.com/4212483/84193769-f3651f00-aa69-11ea-8425-960f1b169ce1.png">

Network errors (i.e. those passed to an `XMLHttpRequest` `onerror` handler) will expand to this:
<img width="1195" alt="ty-network-error jpg" src="https://user-images.githubusercontent.com/4212483/84194674-615e1600-aa6b-11ea-94ce-375e789571a5.png">
Note that neither Firefox nor Chrome provide any more details as to the cause of a network failure, so no other information is available.

HTTP errors with status >= 500 will expand to this:
<img width="1480" alt="ty-500-error" src="https://user-images.githubusercontent.com/4212483/84194208-afbee500-aa6a-11ea-8c8a-542a222bad8b.png">

Other HTTP errors will be rendered without the response body.