### PR TITLE
Change the URL used to save an upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Removed AppLand URL from the popup.
 - Update styling
+- Update URL to start an upload
 
 ## [0.1.0] - 2020-05-28
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   
 ### Changed
 - Removed AppLand URL from the popup.
-- Update styling
-- Update URL to start an upload
+- Update styling.
+- Update URL to start an upload.
+- Close the popup when starting or stopping a recording.
 
 ## [0.1.0] - 2020-05-28
 ### Added

--- a/error_log/error_log.js
+++ b/error_log/error_log.js
@@ -80,14 +80,18 @@ async function showErrors() {
       <li><span class="error-label">msg:</span> ${entry.msg}</li>
 `;
       if (entry.resp) {
-        error += `<li><span class="error-label">resp:</span> ${entry.resp}</li>\n`;
+        error += `<li><span class="error-label">resp:</span><pre class="error-resp"></pre></li>\n`;
       }
       error += `
     </ul>
 </details>
 `;
-      
-      allErrorsDiv.insertAdjacentHTML('afterbegin', error);
+      const tmpl = document.createElement('template');
+      tmpl.innerHTML = error;
+      if (entry.resp) {
+        tmpl.content.querySelector('pre.error-resp').innerText = entry.resp;
+      }
+      allErrorsDiv.appendChild(tmpl.content);
     });
     if (allErrorsDiv.childElementCount === 0) {
       const noErrorsText = document.createTextNode('No errors');

--- a/options/options.js
+++ b/options/options.js
@@ -1,6 +1,8 @@
 import * as utils from '/utils.js';
 
 export default function Options() {
+
+  // AppLand URL
   this.defaultAppLandUrl = () => chrome.runtime.getManifest().homepage_url;
   const applandUrlKey = 'applandUrl';
   this.getAppLandUrl = async () => 
@@ -11,11 +13,11 @@ export default function Options() {
           : this.setAppLandUrl(this.defaultAppLandUrl())
         );
 
-  this.setAppLandUrl = async (url) => {
-    return utils.writeToStorage(applandUrlKey, url);
-  };
-  
+  this.setAppLandUrl = async (url) => 
+    utils.writeToStorage(applandUrlKey, url);
 
+  
+  // Show Target URL
   const showTargetKey = 'showTarget';
   this.getShowTarget = async () => 
     utils.readFromStorage(showTargetKey)
@@ -29,6 +31,7 @@ export default function Options() {
     utils.writeToStorage(showTargetKey, showTarget);
 
 
+  // Target URL
   const targetUrlsKey = 'targetUrls';
   this.getTargetUrl = async (url) => 
     utils.readFromStorage(targetUrlsKey)
@@ -42,11 +45,7 @@ export default function Options() {
       });
   this.getAllTargetUrls = async () => utils.readFromStorage(targetUrlsKey);
 
-  const defaultTargetUrlKey = 'defaultTargetUrl';
-  const getDefaultTargetUrl = async () => utils.readFromStorage(defaultTargetUrlKey);
-  this.setDefaultTargetUrl = async (defaultTarget) => 
-    utils.writeToStorage(defaultTargetUrlKey, defaultTarget.origin);
-
+  // Save Errors
   const saveErrorsKey = 'saveErrors';
   this.getSaveErrors = async () => 
     utils.readFromStorage(saveErrorsKey)
@@ -58,5 +57,4 @@ export default function Options() {
 
   this.setSaveErrors = async (saveErrors) => 
     utils.writeToStorage(saveErrorsKey, saveErrors);
-
 };

--- a/popup/record.css
+++ b/popup/record.css
@@ -134,6 +134,7 @@ input[type=checkbox]:checked + .appmap-record-button:before {
 
 #target_form.hidden {
   visibility: hidden;
+  display: inherit;
   height: 0;
   width: 16rem;
 }

--- a/popup/record.html
+++ b/popup/record.html
@@ -28,7 +28,7 @@
         </div>
         
       </form>
-      <div class="status">Preparing</div>
+      <div class="status">Checking recording status</div>
       
     </div>
 

--- a/popup/record.js
+++ b/popup/record.js
@@ -95,8 +95,8 @@ async function onLoad() {
           displayRecording(recordingState.enabled);
           setEnabled(true);
         } else {
-          utils.showXHRError(req, 'Failed checking recording status');
-          setStatus('Not available for this domain');
+          utils.showXHRError(req, 'Does not support AppLand recording');
+          setStatus('Does not support AppLand recording');
         }
       };
       req.onerror = () => {

--- a/popup/record.js
+++ b/popup/record.js
@@ -42,7 +42,8 @@ let getTabInfo = null;
 
 header.addEventListener('click', onHeaderClick);
 recordBtn.addEventListener('change', (e) => {
-  e.target.checked ? startRecording() : stopRecording();
+  const action  = e.target.checked ? startRecording : stopRecording;
+  action().then(() => !underTest? window.close() : null);
 });
 
 async function onLoad() {
@@ -197,20 +198,24 @@ async function setRecordingTarget(newTarget) {
     });
 }
           
-function startRecording() {
-  getRecordingTarget()
+async function startRecording() {
+  return getRecordingTarget()
     .then((target) => {
-      const req = new XMLHttpRequest();
-      req.open('POST', `${target.url.origin}/_appmap/record`);
-      req.onload = () => {
-        if (req.status === 200) {
-          displayRecording(true);
-        }
-        else {
-          utils.showXHRError(req, 'Failed to start recording');
-        }
-      };
-      req.send();
+      return new Promise((resolve, reject) => {
+        const req = new XMLHttpRequest();
+        req.open('POST', `${target.url.origin}/_appmap/record`);
+        req.onload = () => {
+          if (req.status === 200) {
+            displayRecording(true);
+            resolve();
+          }
+          else {
+            utils.showXHRError(req, 'Failed to start recording')
+              .then(resolve);
+          }
+        };
+        req.send();
+      });
     })
     .catch((error) => {
       handleInternalError(error);
@@ -218,12 +223,17 @@ function startRecording() {
 }
 
 async function stopRecording() {
-  getRecordingTarget()
+  return getRecordingTarget()
     .then((target) => {
-      chrome.tabs.create({
-        url: `/popup/save.html?url=${target.url.origin}`,
-        windowId: target.windowId
-      }, () => displayRecording(false));
+      return new Promise((resolve, reject) => {
+        chrome.tabs.create({
+          url: `/popup/save.html?url=${target.url.origin}`,
+          windowId: target.windowId
+        }, () => {
+          displayRecording(false);
+          resolve();
+        });
+      });
     })
     .catch((error) => {
       handleInternalError(error);

--- a/popup/save.js
+++ b/popup/save.js
@@ -26,11 +26,8 @@ async function saveScenario(data) {
   const form = document.querySelector('form');
   return options.getAppLandUrl()
     .then((applandUrl) => {
-      return options.getEditUpload()
-        .then((editUpload) => {
-          form.setAttribute('action', `${applandUrl}/scenario_uploads`);
-          form.querySelector('input').value = JSON.stringify(data);
-          form.submit();
-        });
+      form.setAttribute('action', `${applandUrl}/scenario_uploads`);
+      form.querySelector('input').value = JSON.stringify(data);
+      form.submit();
     });
 }

--- a/popup/save.js
+++ b/popup/save.js
@@ -24,8 +24,13 @@ function onLoad() {
 
 async function saveScenario(data) {
   const form = document.querySelector('form');
-  const applandUrl = await options.getAppLandUrl();
-  form.setAttribute('action', `${applandUrl}/scenarios`);
-  form.querySelector('input').value = JSON.stringify(data);
-  form.submit();
+  return options.getAppLandUrl()
+    .then((applandUrl) => {
+      return options.getEditUpload()
+        .then((editUpload) => {
+          form.setAttribute('action', `${applandUrl}/scenario_uploads`);
+          form.querySelector('input').value = JSON.stringify(data);
+          form.submit();
+        });
+    });
 }

--- a/popup/save.js
+++ b/popup/save.js
@@ -16,8 +16,11 @@ function onLoad() {
       }
     }
     else {
-      utils.showXHRError(req, 'Failed saving recording');
+      utils.showXHRError(req, 'Failed fetching recording');
     }
+  };
+  req.onerror = () => {
+    utils.showXHRError(req, 'Network error fetching recording');
   };
   req.send();
 }

--- a/settings/settings.html
+++ b/settings/settings.html
@@ -37,14 +37,12 @@
             <a href="/error_log/error_log.html" id="errors_link">Error Log</a>
           </div>
           </section>
-          
+
         </div>
 
       
         <button class="btn btn-primary controls" id="save" disabled>Save</button>
       </form>
-
-      <a href="/options/test.html">Options Test</a>
     </div>
     
     <script src="settings.js" type="module"></script>


### PR DESCRIPTION
These changes update the URL used to save a recording, required because of changes to AppLand: https://github.com/applandinc/appland/pull/489 .

Also, close the popup when the Record button is clicked; and fix the styling of the popup when the target URL is hidden.