### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0] = 2020-060-29
 ### Added
 - An Error Log, showing the last 100 errors from `XMLHttpRequest`s. Available from the
   extension settings page.
@@ -29,4 +29,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `homepage_url` now points at https://app.land .
 - Add Firefox to Development section of README.
 
+[0.2.0]: https://github.com/applandinc/appland-browser-extension/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/applandinc/appland-browser-extension/releases/tag/v0.1.0

--- a/error_log/error_log.js
+++ b/error_log/error_log.js
@@ -61,8 +61,8 @@ async function showErrors() {
   const newestFirst = newestFirstBtn.checked;
   
   getErrors().then((entries) => {
-    const sorted = entries.sort((e1,e2) => 
-      newestFirst? compare(e1,e2) : compare(e2,e1)
+    entries = entries.sort((e1,e2) => 
+      newestFirst? compare(e2,e1) : compare(e1,e2)
     );
 
     const allErrorsDiv = document.createElement('div');

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 
   "manifest_version": 2,
   "name": "AppLand",
-  "version": "0.2",
+  "version": "0.2.0",
 
   "description": "Control your AppLand AppMap recordings from the browser",
   "homepage_url": "https://app.land",


### PR DESCRIPTION
Note that I originally thought the format for the `version` entry in `manifest.json` would not allow a semantic-version triple. After more reading, I see that it will, so I changed the format.

Also, these changes fix a problem sorting error log entries.